### PR TITLE
feat: add support for @ syntax expressions in CLI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,24 +3,41 @@
 const cronstrue = require('../dist/cronstrue');
 
 function usage() {
+  console.error("Usage: cronstrue \"<expression>\"");
+  console.error("  or");
   console.error("Usage (5 args): cronstrue minute hour day-of-month month day-of-week");
-  console.error("or")
+  console.error("  or");
   console.error("Usage (6 args): cronstrue second minute hour day-of-month month day-of-week");
-  console.error("or")
+  console.error("  or");
   console.error("Usage (7 args): cronstrue second minute hour day-of-month month day-of-week year");
+  console.error("");
+  console.error("Examples:");
+  console.error("  cronstrue \"*/5 * * * *\"");
+  console.error("  cronstrue \"@daily\"");
+  console.error("  cronstrue 0 0 * * 1");
 }
 
-const args = process.argv.slice(2).join(" ");
-const argCount = args.trim().split(/\s+/).length;
+const args = process.argv.slice(2);
+
+// Handle the case where a single argument is provided, which might be a complete cron expression or special @ syntax
+if (args.length === 1) {
+  console.log(cronstrue.toString(args[0]));
+  process.exit(0);
+}
+
+// Handle the 5-7 arguments case
+const expression = args.join(" ");
+const argCount = args.length;
 if (argCount < 5) {
-  console.error(`Error: too few arguments (${argCount}): ${args}`);
-  usage()
+  console.error(`Error: too few arguments (${argCount}): ${expression}`);
+  usage();
   process.exit(1);
 }
 
 if (argCount > 7) {
-  console.error(`Error: too many arguments (${argCount}): ${args}`);
+  console.error(`Error: too many arguments (${argCount}): ${expression}`);
   usage();
   process.exit(2);
 }
-console.log(cronstrue.toString(args));
+
+console.log(cronstrue.toString(expression));


### PR DESCRIPTION
## Summary
- Add ability to parse single argument expressions including @ syntax in the CLI
- Enhance usage text with examples of @ syntax and quoted expressions
- Maintain backward compatibility with space-separated arguments format

## Use Case
This enables tools like [cronex.nvim](https://github.com/fabridamicelli/cronex.nvim) to use the CLI for translating special @ syntax expressions like @daily and @monthly as seen in https://github.com/fabridamicelli/cronex.nvim/pull/8.

## Testing
Manual testing confirms that the following formats now work:
- `cronstrue "@daily"` → "At 12:00 AM"
- `cronstrue "@monthly"` → "At 12:00 AM, on day 1 of the month"
- `cronstrue "*/5 * * * *"` → "Every 5 minutes"

The existing multi-argument format continues to work as before.